### PR TITLE
Add 'serve-local' command to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ all: prep fetch-data create-html
 
 define check-venv
 	@echo "Checking if virtual environment is activated..." && \
-	if [ -z "$$VIRTUAL_ENV" ]; then \
-		echo "Please activate the virtual environment first."; \
+	if [ -z "$$VIRTUAL_ENV" ] && [ -z "$$CONDA_DEFAULT_ENV"]; then \
+		echo "Please activate a virtual environment first (venv or conda)."; \
 		exit 1; \
 	else \
 		echo "Virtual environment is activated...hopefully it's the right one!"; \

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,31 @@
 BUILDDIR := ./_build
+FETCH_DATA_COMPLETE := $(BUILDDIR)/data/.complete
+CREATE_HTML_COMPLETE := $(BUILDDIR)/plugins/.complete
 
-.PHONY: all prep fetch-data create-html
+.PHONY: all clean prep fetch-data create-html serve-local
 
 all: prep fetch-data create-html
 
-prep:
-	@echo "Preparing build directory..."
+define check-venv
+	@echo "Checking if virtual environment is activated..." && \
+	if [ -z "$$VIRTUAL_ENV" ]; then \
+		echo "Please activate the virtual environment first."; \
+		exit 1; \
+	else \
+		echo "Virtual environment is activated...hopefully it's the right one!"; \
+	fi
+endef
+
+clean:
+	@echo "Cleaning up build directory..."
 	rm -rf $(BUILDDIR)
+	@echo "Build directory cleaned."
+
+prep: $(BUILDDIR)
+
+$(BUILDDIR):
+	@echo "Preparing build directory..."
 	mkdir -p $(BUILDDIR)
-	mkdir -p $(BUILDDIR)/data
-	mkdir -p $(BUILDDIR)/plugins
 	mkdir -p $(BUILDDIR)/static
 	cp -r ./templates $(BUILDDIR)/templates
 	cp -r ./static/images $(BUILDDIR)/static/images
@@ -17,12 +33,26 @@ prep:
 	cp ./entire_text_search.js $(BUILDDIR)/entire_text_search.js
 	cp ./index.html $(BUILDDIR)/index.html
 
-fetch-data:
+fetch-data: $(FETCH_DATA_COMPLETE)
+
+$(FETCH_DATA_COMPLETE): $(BUILDDIR)
+	$(call check-venv)
 	@echo "Fetching data..."
+	mkdir -p $(BUILDDIR)/data
 	python ./fetch_napari_data.py $(BUILDDIR)
+	@touch $(FETCH_DATA_COMPLETE)
 	@echo "Data fetched and stored in $(BUILDDIR)/data"
 
-create-html:
+create-html: $(CREATE_HTML_COMPLETE)
+
+$(CREATE_HTML_COMPLETE): $(FETCH_DATA_COMPLETE)
+	$(call check-venv)
 	@echo "Creating HTML files..."
+	mkdir -p $(BUILDDIR)/plugins
 	python ./create_static_html_files.py $(BUILDDIR)
+	@touch $(CREATE_HTML_COMPLETE)
 	@echo "HTML files created in $(BUILDDIR)/plugins"
+
+serve-local: $(CREATE_HTML_COMPLETE)
+	@echo "Starting server..."
+	python3 -m http.server --directory $(BUILDDIR)

--- a/fetch_napari_data.py
+++ b/fetch_napari_data.py
@@ -4,6 +4,7 @@ import json
 import os
 import pandas as pd
 import re
+from concurrent.futures import ThreadPoolExecutor
 
 def fetch_conda(plugin_name):
     """ Fetches Conda info and creates an HTML file for it """
@@ -57,8 +58,8 @@ def build_plugins_dataframe():
 
     all_plugin_data = []
 
-    for plugin in plugin_summary:
-        plugin_data = plugin.copy()  
+    def process_plugin(plugin):
+        plugin_data = plugin.copy()
         plugin_name = plugin.get('name')
 
         # Fetch and flatten Conda info and Manifest
@@ -72,7 +73,9 @@ def build_plugins_dataframe():
             flatten_and_merge(plugin_data, manifest_info)
 
         all_plugin_data.append(plugin_data)
-        #print(pd.DataFrame(all_plugin_data))
+
+    with ThreadPoolExecutor() as executor:
+        executor.map(process_plugin, plugin_summary)
 
     df = pd.DataFrame(all_plugin_data)
     return df


### PR DESCRIPTION
This is related to #27, but does not close because it's for local dev only.

This adds a `serve-local` target to the Makefile. Now you can run `make serve-local` and see the site, including JS, in your local browser.
![Screenshot 2025-05-20 at 10 05 39 PM](https://github.com/user-attachments/assets/2db35d9a-8b81-49ec-9b84-77a7da6046ed)

In order to make this properly build as-needed I added sentinel files for the other build steps, but kept the command aliases the same. I'm not a huge fan of nor expert in make, so I'm happy to take input or revert this.

The other change here is to use a `ThreadPoolExecutor` to fetch plugin data concurrently. This produces a pretty big speedup for me:

```
# before
> /usr/bin/time make fetch-data
Data fetched and stored in ./_build/data
      253.60 real         8.37 user         2.72 sys

#after
> /usr/bin/time make fetch-data   
Data fetched and stored in ./_build/data
      19.44 real         4.85 user         1.37 sys
```

