### PR TITLE
Add typing stubs for requests for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,7 @@ repos:
   rev: v1.16.0
   hooks:
     -  id: mypy
+       additional_dependencies: [types-requests]
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: "v5.0.0"
   hooks:
@@ -34,3 +35,6 @@ repos:
     - id: requirements-txt-fixer
     - id: trailing-whitespace
       exclude: .*\.md
+
+default_language_version:
+    python: python3.13

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Napari Hub Lite
 
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/napari/hub-lite/main.svg)](https://results.pre-commit.ci/latest/github/napari/hub-lite/main)
+
+
 ### Author: Yunha Lee
 
 ### Disclaimer

--- a/fetch_napari_data.py
+++ b/fetch_napari_data.py
@@ -9,7 +9,6 @@ import logging
 import re
 import sys
 from concurrent.futures import ThreadPoolExecutor
-from typing import list
 from urllib.parse import urljoin
 
 import pandas as pd

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ mypy
 pandas
 pygments
 requests
+types-requests


### PR DESCRIPTION
This PR:
- adds typing-requests to requirements
- updates pre-commit config to add additional dependencies for requests types
- removes unneeded built-in list type
- add badge to README

This change is needed so the scheduled cron job for deploy will run without error and merges to main do not error. See https://github.com/napari/hub-lite/actions/runs/15659702436/job/44115658004