### PR TITLE
Enable bandit in pre-commit to check for potential security vulnerabilities

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,7 @@ repos:
   rev: v1.16.0
   hooks:
     -  id: mypy
+       additional_dependencies: [types-requests]
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: "v5.0.0"
   hooks:
@@ -34,3 +35,6 @@ repos:
     - id: requirements-txt-fixer
     - id: trailing-whitespace
       exclude: .*\.md
+
+default_language_version:
+    python: python3.13

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Napari Hub Lite
 
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/napari/hub-lite/main.svg)](https://results.pre-commit.ci/latest/github/napari/hub-lite/main)
+
+
 ### Author: Yunha Lee
 
 ### Disclaimer

--- a/create_static_html_files.py
+++ b/create_static_html_files.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import json
 import logging
 import os
@@ -165,7 +166,11 @@ def generate_open_extensions_html(row):
     if not pd.isna(row.get("contributions_readers_0_filename_patterns")) and row.get(
         "contributions_readers_0_filename_patterns"
     ):
-        filename_patterns = eval(row.get("contributions_readers_0_filename_patterns"))
+        # We use ast.literal_eval to safely evaluate the string representation
+        # of the list; this is safer than using eval.
+        filename_patterns = ast.literal_eval(
+            row.get("contributions_readers_0_filename_patterns")
+        )
 
         if filename_patterns:
             open_extensions_html = '<ul class="MetadataList_list__3DlqI list-none text-sm leading-normal inline space-y-sds-s MetadataList_inline__jHQLo">'
@@ -182,10 +187,14 @@ def generate_save_extensions_html(row):
     # Gather file extensions from both columns
     file_extensions = []
     if not pd.isna(row.get("contributions_writers_0_filename_extensions")):
-        file_extensions += eval(row.get("contributions_writers_0_filename_extensions"))
+        file_extensions += ast.literal_eval(
+            row.get("contributions_writers_0_filename_extensions")
+        )
 
     if not pd.isna(row.get("contributions_writers_1_filename_extensions")):
-        file_extensions += eval(row.get("contributions_writers_1_filename_extensions"))
+        file_extensions += ast.literal_eval(
+            row.get("contributions_writers_1_filename_extensions")
+        )
 
     if file_extensions:
         save_extensions_html = '<ul class="MetadataList_list__3DlqI list-none text-sm leading-normal inline space-y-sds-s MetadataList_inline__jHQLo">'
@@ -202,7 +211,7 @@ def generate_requirements_html(row):
     if not pd.isna(row.get("package_metadata_requires_dist")) and row.get(
         "package_metadata_requires_dist"
     ):
-        requirements = eval(row.get("package_metadata_requires_dist"))
+        requirements = ast.literal_eval(row.get("package_metadata_requires_dist"))
 
         if requirements:
             requirements_html = (

--- a/fetch_napari_data.py
+++ b/fetch_napari_data.py
@@ -9,7 +9,6 @@ import logging
 import re
 import sys
 from concurrent.futures import ThreadPoolExecutor
-from typing import list
 from urllib.parse import urljoin
 
 import pandas as pd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ select = [
     "B",  # flake8-bugbear
     "SIM",  # flake8-simplify
     "I",  # isort
+    "S",  # flake8-bandit
 ]
 ignore = [
   "E501",  # line too long

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ mypy
 pandas
 pygments
 requests
+types-requests


### PR DESCRIPTION
This PR extends #46 to enable ruff to run pyflakes-bandit and changes `eval` to `ast.literal_eval`. 