### PR TITLE
Correct zizmor security best practice to avoid persisting credential

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
     - name: Check out repository
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Set up Python
       uses: actions/setup-python@v4


### PR DESCRIPTION
Be explicit in checkout of code not to persist credential.

Addresses https://github.com/napari/hub-lite/security/code-scanning/1