### PR TITLE
Run GitHub action for deploy four times per day

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -1,14 +1,16 @@
-name: Fetch Data, Build HTML & Deploy
+name: Build and deploy site
 
 on:
   schedule:
-    - cron: '0 5 * * *' # Runs at 05:00 UTC every day
+    # Run 4x per day, offset to 20 min after hour to avoid peak GitHub load
+    - cron: '20 2,8,14,20 * * *'  # 2:20 AM, 8:20 AM, 2:20 PM, 8:20 PM UTC
   # You can also trigger this workflow manually
   workflow_dispatch:
 
 jobs:
   run-scripts:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
 


### PR DESCRIPTION
This PR increases the deploy frequency from once a day to four times a day. The deploy action four times a day at 20 minutes after the hour to avoid GitHub peak times. Adds a timeout to conserve action minutes on failed builds.

Four times a day seems a nice balance between once a day and hourly. If plugins release updates, it will take at most six hours to see the updates on hublite. We can always increase frequency if needed in the future.

Closes #2