### PR TITLE
Add logic to truncate the license metadata for display

### DIFF
--- a/fetch_napari_data.py
+++ b/fetch_napari_data.py
@@ -356,13 +356,16 @@ if __name__ == "__main__":
                 row["package_metadata_author_email"]
             )
 
+        # For license metadata, we subsitute a short phrase, truncate the text,
+        # or add a sensible default if the text is unavailable.
         if pd.isna(row["license"]):
-            pass
-        # Check for specific license strings to shorten the license information
+            df_plugins.at[index, "license"] = "Unavailable"
         elif "BSD 3-Clause" in str(row["license"]):
             df_plugins.at[index, "license"] = "BSD 3-Clause"
         elif "MIT License" in str(row["license"]):
             df_plugins.at[index, "license"] = "MIT"
+        elif '"' in str(row["license"]):
+            df_plugins.at[index, "license"] = f"{row['license'][:30]}..."
 
         # Fill home_pypi
         if not row["home_pypi"]:

--- a/templates/each_plugin_template.html
+++ b/templates/each_plugin_template.html
@@ -98,9 +98,9 @@
                                     <div class="">
                                         <p class="font-bold whitespace-nowrap">License<!-- -->:</p>
                                         <ul class="MetadataList_list__3DlqI list-none text-sm leading-normal">
-                                            <li class="MetadataList_textItem__KKmMN"><a
-                                                    class="MetadataList_textItem__KKmMN underline"
-                                                    href="../index.html?license=oss">${license}</a></li>
+                                            <li class="MetadataList_textItem__KKmMN">
+                                                ${license}
+                                            </li>
                                         </ul>
                                     </div>
                                 </div>
@@ -245,9 +245,9 @@
                                                 </p>
                                                 <ul
                                                     class="MetadataList_list__3DlqI list-none text-sm leading-normal inline space-y-sds-s MetadataList_inline__jHQLo">
-                                                    <li class="MetadataList_textItem__KKmMN"><a
-                                                            class="MetadataList_textItem__KKmMN underline"
-                                                            href="../index.html?license=oss">${license}</a></li>
+                                                    <li class="MetadataList_textItem__KKmMN">
+                                                            ${license}
+                                                    </li>
                                                 </ul>
                                             </div>
                                         </div>
@@ -407,6 +407,7 @@
                     </svg></a>
             </div>
     </div>
+  </div>
 </body>
 
 </html>


### PR DESCRIPTION
Closes #21.

This PR adds additional logic when checking license metadata. If no metadata exists, it is now set to "Unavailable". If metadata text exists but is not a common license, the text is truncated to 30 characters.

Removes the metadata license link that only redirected to the hublite main page.