### PR TITLE
Parse pypi and github URLs correctly

### DIFF
--- a/fetch_napari_data.py
+++ b/fetch_napari_data.py
@@ -138,7 +138,8 @@ def expand_proj_url(plugin_data: dict) -> None:
         The function modifies the `plugin_data` dictionary in place.
     """
     urls = plugin_data.get("project_url", [])
-    # old metadata spec just used 'home_page' key so we try grabbing that
+
+    # If urls do not exist, we try using the 'home_page' key (like in the old metadata spec).
     if not urls and "home_page" in plugin_data:
         urls = f"homepage, {plugin_data['home_page']}"
 
@@ -148,9 +149,9 @@ def expand_proj_url(plugin_data: dict) -> None:
         label, url = url_info.split(", ")
         plugin_data[normalize_label(label)] = url
         if re.match(HOME_GITHUB_REGEX, url):
-            # if url matches github repository links,
-            # we present it with the github icon
-            # otherwise we present the homepage label
+            # If url matches github repository link structure,
+            # we display the github icon.
+            # Otherwise, display the homepage label
             # as some other url
             plugin_data["home_github"] = url
         elif label == "homepage":

--- a/fetch_napari_data.py
+++ b/fetch_napari_data.py
@@ -314,8 +314,6 @@ def build_plugins_dataframe() -> pd.DataFrame:
         pypi_info = fetch(urljoin(API_PYPI_BASE_URL, plugin_normalized_name))
 
         expand_proj_url(plugin_data)
-        if plugin_data["name"] == "affinder":
-            print("HEY")
 
         if conda_info:
             # we only want a limited set of conda info
@@ -353,8 +351,6 @@ def build_plugins_dataframe() -> pd.DataFrame:
 
     with ThreadPoolExecutor() as executor:
         executor.map(process_plugin, summary_df)
-    # for plugin in summary_df:
-    #     process_plugin(plugin)
 
     return pd.DataFrame(all_plugin_data)
 


### PR DESCRIPTION
Prior to this PR our retrieval of github URLs was missing many plugins because it did not inspect the `project_url` field. This PR updates the logic for fetching this information to include checking both the `home_page` and `project_url`. It also retrieves the PyPI url from the PyPI api information as this is likely to be more stable.

In future we should also add a link to the conda URL information (if present), and potentially parse documentation/bugtracker/etc. links for display. However that would require more icons/CSS/layout changes and I'd rather get #75 and #81 done first. I thought this was valuable enough to get it in asap.