### PR TITLE
Redirect plugin paths to the normalized path inclusive of '.html'

### DIFF
--- a/404.html
+++ b/404.html
@@ -20,6 +20,6 @@
   <h1>404 — Page not found</h1>
   <p>If this was a plugin URL, you will be redirected automatically.</p>
 
-  <script src="static/js/redirect_404.js"></script>
+  <script src="/static/js/redirect_404.js"></script>
 </body>
 </html>

--- a/404.html
+++ b/404.html
@@ -20,6 +20,6 @@
   <h1>404 — Page not found</h1>
   <p>If this was a plugin URL, you will be redirected automatically.</p>
 
-  <script src="/static/js/redirect_404.js"></script>
+  <script src="/hub-lite/static/js/redirect_404.js"></script>
 </body>
 </html>

--- a/404.html
+++ b/404.html
@@ -20,6 +20,6 @@
   <h1>404 — Page not found</h1>
   <p>If this was a plugin URL, you will be redirected automatically.</p>
 
-  <script src="/hub-lite/static/js/redirect_404.js"></script>
+  <script src="/static/js/redirect_404.js"></script>
 </body>
 </html>

--- a/404.html
+++ b/404.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta content="width=device-width" name="viewport" />
+    <link href="https://www.napari-hub.org/plugins" rel="canonical" />
+    <title>Page not found</title>
+    <meta content="2" name="next-head-count" />
+    <meta content="#80d1ff" name="theme-color" />
+    <meta content="#009bf2" name="msapplication-TileColor" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:ital,wght@0,400;0,700;1,400;1,700&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&display=swap" rel="stylesheet">
+    <link as="style" href="./static/css/8ebdfa69bbc45988.css" rel="preload" />
+    <link data-n-g="" href="./static/css/8ebdfa69bbc45988.css" rel="stylesheet" /><noscript data-n-css=""></noscript>
+    <link href="./static/css/all_plugins_styles.css" rel="stylesheet" type="./css" />
+</head>
+
+<body>
+  <h1>404 — Page not found</h1>
+  <p>If this was a plugin URL, you will be redirected automatically.</p>
+
+  <script src="static/js/redirect_404.js"></script>
+</body>
+</html>

--- a/404.html
+++ b/404.html
@@ -1,24 +1,21 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="utf-8" />
-    <meta content="width=device-width" name="viewport" />
     <link href="https://www.napari-hub.org/plugins" rel="canonical" />
     <title>Page not found</title>
-    <meta content="2" name="next-head-count" />
-    <meta content="#80d1ff" name="theme-color" />
-    <meta content="#009bf2" name="msapplication-TileColor" />
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:ital,wght@0,400;0,700;1,400;1,700&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&display=swap" rel="stylesheet">
-    <link as="style" href="./static/css/8ebdfa69bbc45988.css" rel="preload" />
-    <link data-n-g="" href="./static/css/8ebdfa69bbc45988.css" rel="stylesheet" /><noscript data-n-css=""></noscript>
-    <link href="./static/css/all_plugins_styles.css" rel="stylesheet" type="./css" />
 </head>
 
 <body>
-  <h1>404 — Page not found</h1>
-  <p>If this was a plugin URL, you will be redirected automatically.</p>
+  <h1>404 - Page not found</h1>
+  <p>
+    The napari hub has been moved to a <a class="underline" href="https://github.com/napari/hub-lite" target="_blank">community-maintained project</a>, and re-architected as a static site.
+    If this was a plugin URL, you should be redirected automatically.
+    If you are not redirected, visit the <a href="/">main napari hub page</a> to search for the plugin or page you were looking for.
+  </p>
+
+  <p>
+    If you followed this link from another page, please consider contacting the author about updating the source.
+  </p>
 
   <script src="/static/js/redirect_404.js"></script>
 </body>

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ $(BUILDDIR):
 	cp -r ./static/css $(BUILDDIR)/static/css
 	cp -r ./static/js $(BUILDDIR)/static/js
 	cp ./index.html $(BUILDDIR)/index.html
+	cp ./404.html $(BUILDDIR)/404.html
 
 fetch-data: $(FETCH_DATA_COMPLETE)
 

--- a/static/js/redirect_404.js
+++ b/static/js/redirect_404.js
@@ -1,10 +1,17 @@
+// Try to recover from 404 by normalizing plugin names
+// and adding the required '.html' extension
 (function() {
     const path = window.location.pathname;
-    const isPlugin = path.startsWith('/plugins/') && !path.endsWith('.html');
+    const isPlugin = path.startsWith('/plugins/');
     if (isPlugin) {
       // Extract plugin name (last part after last '/')
       const parts = path.split('/');
-      const pluginName = parts[parts.length - 1];
+      var pluginName = parts[parts.length - 1];
+
+      if (pluginName.endsWith('.html')) {
+        // Remove the '.html' extension, before reconstructing the URL
+        pluginName = pluginName.slice(0, -5);
+      }
 
       const normalized = normalizeName(pluginName);
       const newPath = path.slice(0, path.lastIndexOf('/') + 1) + normalized + '.html';

--- a/static/js/redirect_404.js
+++ b/static/js/redirect_404.js
@@ -2,7 +2,7 @@
 // and adding the required '.html' extension
 (function() {
     const path = window.location.pathname;
-    const isPlugin = path.startsWith('/plugins/');
+    const isPlugin = path.includes('/plugins/');
     console.log(isPlugin, path);
     if (isPlugin) {
       // Extract plugin name (last part after last '/')

--- a/static/js/redirect_404.js
+++ b/static/js/redirect_404.js
@@ -17,7 +17,7 @@
       const newPath = path.slice(0, path.lastIndexOf('/') + 1) + normalized + '.html';
 
       console.log(newPath);
-      fetch(checkPath, { method: 'HEAD' })
+      fetch(newPath, { method: 'HEAD' })
         .then(response => {
             if (response.ok) {
             console.log("Exists!");

--- a/static/js/redirect_404.js
+++ b/static/js/redirect_404.js
@@ -1,0 +1,8 @@
+(function() {
+    const path = window.location.pathname;
+    const isPlugin = path.startsWith('/plugins/') && !path.endsWith('.html');
+
+    if (isPlugin) {
+      window.location.replace(path + '.html');
+    }
+  })();

--- a/static/js/redirect_404.js
+++ b/static/js/redirect_404.js
@@ -20,10 +20,7 @@
       fetch(newPath, { method: 'HEAD' })
         .then(response => {
             if (response.ok) {
-            console.log("Exists!");
-            window.location.replace(newPath);
-            } else {
-            console.log("Does not exist!");
+              window.location.replace(newPath);
             }
         });
 

--- a/static/js/redirect_404.js
+++ b/static/js/redirect_404.js
@@ -8,11 +8,13 @@
       // Extract plugin name (last part after last '/')
       const parts = path.split('/');
       var pluginName = parts[parts.length - 1];
+      console.log(pluginName);
 
       if (pluginName.endsWith('.html')) {
         // Remove the '.html' extension, before reconstructing the URL
         pluginName = pluginName.slice(0, -5);
       }
+      console.log(pluginName);
 
       const normalized = normalizeName(pluginName);
       const newPath = path.slice(0, path.lastIndexOf('/') + 1) + normalized + '.html';

--- a/static/js/redirect_404.js
+++ b/static/js/redirect_404.js
@@ -15,7 +15,18 @@
 
       const normalized = normalizeName(pluginName);
       const newPath = path.slice(0, path.lastIndexOf('/') + 1) + normalized + '.html';
-      window.location.replace(newPath);
+
+      console.log(newPath);
+      fetch(checkPath, { method: 'HEAD' })
+        .then(response => {
+            if (response.ok) {
+            console.log("Exists!");
+            window.location.replace(newPath);
+            } else {
+            console.log("Does not exist!");
+            }
+        });
+
     }
 
     function normalizeName(name) {

--- a/static/js/redirect_404.js
+++ b/static/js/redirect_404.js
@@ -3,6 +3,7 @@
 (function() {
     const path = window.location.pathname;
     const isPlugin = path.startsWith('/plugins/');
+    console.log(isPlugin, path);
     if (isPlugin) {
       // Extract plugin name (last part after last '/')
       const parts = path.split('/');
@@ -15,6 +16,7 @@
 
       const normalized = normalizeName(pluginName);
       const newPath = path.slice(0, path.lastIndexOf('/') + 1) + normalized + '.html';
+      console.log(newPath)
       window.location.replace(newPath);
     }
 

--- a/static/js/redirect_404.js
+++ b/static/js/redirect_404.js
@@ -16,7 +16,7 @@
       const normalized = normalizeName(pluginName);
       const newPath = path.slice(0, path.lastIndexOf('/') + 1) + normalized + '.html';
 
-      console.log(newPath);
+      // if the normalized path is a valid page, redirect to it
       fetch(newPath, { method: 'HEAD' })
         .then(response => {
             if (response.ok) {

--- a/static/js/redirect_404.js
+++ b/static/js/redirect_404.js
@@ -3,22 +3,18 @@
 (function() {
     const path = window.location.pathname;
     const isPlugin = path.includes('/plugins/');
-    console.log(isPlugin, path);
     if (isPlugin) {
       // Extract plugin name (last part after last '/')
       const parts = path.split('/');
       var pluginName = parts[parts.length - 1];
-      console.log(pluginName);
 
       if (pluginName.endsWith('.html')) {
         // Remove the '.html' extension, before reconstructing the URL
         pluginName = pluginName.slice(0, -5);
       }
-      console.log(pluginName);
 
       const normalized = normalizeName(pluginName);
       const newPath = path.slice(0, path.lastIndexOf('/') + 1) + normalized + '.html';
-      console.log(newPath)
       window.location.replace(newPath);
     }
 

--- a/static/js/redirect_404.js
+++ b/static/js/redirect_404.js
@@ -1,8 +1,18 @@
-(function() {
+(function () {
     const path = window.location.pathname;
     const isPlugin = path.startsWith('/plugins/') && !path.endsWith('.html');
-
     if (isPlugin) {
-      window.location.replace(path + '.html');
+      // Extract plugin name (last part after last '/')
+      const parts = path.split('/');
+      const pluginName = parts[parts.length - 1];
+
+      const normalized = normalizeName(pluginName);
+      const newPath = path.slice(0, path.lastIndexOf('/') + 1) + normalized + '.html';
+      window.location.replace(newPath);
     }
-  })();
+
+    function normalizeName(name) {
+        return name.replace(/[-_.]+/g, "-").toLowerCase();
+  }
+
+})();

--- a/static/js/redirect_404.js
+++ b/static/js/redirect_404.js
@@ -1,4 +1,4 @@
-(function () {
+(function() {
     const path = window.location.pathname;
     const isPlugin = path.startsWith('/plugins/') && !path.endsWith('.html');
     if (isPlugin) {


### PR DESCRIPTION
Currently a user must specifically request their plugin URL using the normalized name with a `'.html'` suffix, even if their plugin name is not actually normalized.

`napari-hub.org/plugins/PartSeg.html` -> fails
`napari-hub.org/plugins/partseg` -> fails
`napari-hub.org/plugins/partseg.html` -> succeeds

This PR tries to set up a javascript client-side redirect from a custom 404 page so that if users enter one of the first two options, they still see the correct plugin page.

The issue with this PR is that it can't be tested locally (because the python server won't use our 404 page), but you can test it live at my fork e.g. https://dragadoncila.github.io/hub-lite/plugins/PaRtSeG

Problems:

- we'd have to yolo merge because idk how to preview this properly :grimacing: 
- the CSS styling isn't right, the 404 page is just ugly plain html
- I'm not confident that the link from 404.html to the `redirect_404.js` script is correct for the actual hub domain
- I have no idea if this is generally bad practice, but I think it's roughly the only way to do a client-side redirect rather than just writing out multiple files?

If people think this is a valid path forward I can try to get some CSS going and think of ways to test without deployment (or we could YOLO it), but I wanted to just put it out there first :woman_shrugging: 