### PR TITLE
Update circleci.yml to add an id to redirector step so it can be referenced in the check step

### DIFF
--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -12,6 +12,7 @@ jobs:
     name: Run CircleCI artifacts redirector
     steps:
       - name: GitHub Action step
+        id: redirector
         uses:
           scientific-python/circleci-artifacts-redirector-action@839631420e45a08af893032e5a5e8843bf47e8ff  # v1.2.0
         with:
@@ -24,4 +25,4 @@ jobs:
       - name: Check the URL
         if: github.event.status != 'pending'
         run: |
-          curl --fail ${{ steps.step1.outputs.url }} | grep $GITHUB_SHA
+          curl --fail ${{ steps.redirector.outputs.url }} | grep $GITHUB_SHA


### PR DESCRIPTION
In order to reference something from one step to another the step needs to have an id.
This PR adds an id to the step named "GitHub Action step" and then references that step id in the step named "Check the URL"
This should resolve the action failures, e.g. https://github.com/napari/hub-lite/actions/runs/16544347009
In that example, the redirector works properly, everything is accessible, but the Check step throws an error because of the URL being missing.