### PR TITLE
Update circleci.yml to remove the Check url step

### DIFF
--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -21,8 +21,3 @@ jobs:
           artifact-path: 0/build-artifacts/index.html
           circleci-jobs: build-site
           job-title: View the hub-lite preview
-      # See example https://github.com/scientific-python/circleci-artifacts-redirector-action
-      - name: Check the URL
-        if: github.event.status != 'pending'
-        run: |
-          curl --fail ${{ steps.redirector.outputs.url }} | grep $GITHUB_SHA


### PR DESCRIPTION
So in https://github.com/napari/hub-lite/pull/95 getting the URL of the artifact was fixed.
You can see that it is correct here:
https://github.com/napari/hub-lite/actions/runs/16545316219/job/46792055503#step:3:51
However you see the job failure.
that's because the actual file index.html does not contain the github SHA.
 I'm not sure why it would?

So this PR just removes that step -- we don't use it in napari/napari or napari/docs.

