### PR TITLE
Improve classifier parsing and GitHub URL extraction

### DIFF
--- a/create_static_html_files.py
+++ b/create_static_html_files.py
@@ -297,8 +297,12 @@ def get_os_html(package_metadata_classifier):
     )
 
     # Split the package_metadata_classifier into a list for easier searching
-    if package_metadata_classifier and str(package_metadata_classifier) not in ["n/a", "none",
-                                                                                "nan", ""]:
+    if package_metadata_classifier and str(package_metadata_classifier) not in [
+        "n/a",
+        "none",
+        "nan",
+        "",
+    ]:
         classifier_items = package_metadata_classifier.strip("[]").split(",")
     else:
         classifier_items = []

--- a/create_static_html_files.py
+++ b/create_static_html_files.py
@@ -297,7 +297,11 @@ def get_os_html(package_metadata_classifier):
     )
 
     # Split the package_metadata_classifier into a list for easier searching
-    classifier_items = package_metadata_classifier.strip("]").split(",")
+    if package_metadata_classifier and str(package_metadata_classifier) not in ["n/a", "none",
+                                                                                "nan", ""]:
+        classifier_items = package_metadata_classifier.strip("[]").split(",")
+    else:
+        classifier_items = []
 
     # Compose html from classifier or use the default
     os_html = default_os_html
@@ -314,11 +318,10 @@ def get_os_html(package_metadata_classifier):
 
 
 def extract_github_info(url):
-    match = re.search(r"github\.com/([^/]+)/([^/]+)", url)
-    if match:
-        user, repo = match.group(1), match.group(2).rstrip(".git")
-        return user, repo
-    return None, None
+    match = re.search(r"github\.com/(?P<user>[^/]+)/(?P<repo>[^/]+)(?:\.git)?", url)
+    user = match.group("user") if match else None
+    repo = match.group("repo") if match else None
+    return user, repo
 
 
 def generate_home_html(plugin_name, home_pypi, home_github, home_other):

--- a/fetch_napari_data.py
+++ b/fetch_napari_data.py
@@ -21,7 +21,7 @@ API_CONDA_BASE_URL = "https://npe2api.vercel.app/api/conda/"
 API_PYPI_BASE_URL = "https://npe2api.vercel.app/api/pypi/"
 API_MANIFEST_BASE_URL = "https://npe2api.vercel.app/api/manifest/"
 HOME_PYPI_REGEX = r"(.*)(pypi.org)(/)(project)(/)(.*)"
-HOME_GITHUB_REGEX = r"(http(s)?)(:(//)?)(.*)(github.com)(/)?(.+)(/)(.+)(\.git)?$"
+HOME_GITHUB_REGEX = r"https?://github\.com/[^/]+/[^/]+(?:\.git)?/?$"
 
 # Define columns needed for the plugin html page
 PLUGIN_PAGE_COLUMNS = [


### PR DESCRIPTION
This fixes issues with GitHub links identified in this zulip thread: [#plugins > Hub naming issue](https://napari.zulipchat.com/#narrow/channel/309872-plugins/topic/Hub.20naming.20issue).

This also fixes an issue with parsing classifiers I ran into when building locally - I'm not sure why that's not seen in CI unless it's related to a recent addition on npe2api.